### PR TITLE
Fix pre-commit hook to allow twining_record in same turn as git commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "twining",
       "source": "./plugin",
       "description": "Shared blackboard, decision tracking, and context assembly for multi-agent workflows",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "author": {
         "name": "Dave Angulo"
       },

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twining",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Agent coordination — shared blackboard, decision tracking, and context assembly",
   "author": { "name": "Dave Angulo", "url": "https://github.com/daveangulo" },
   "homepage": "https://github.com/daveangulo/twining-mcp",

--- a/plugin/hooks/pre-commit-hook.sh
+++ b/plugin/hooks/pre-commit-hook.sh
@@ -44,8 +44,11 @@ LAST_COMMIT=${LAST_COMMIT:-0}
 LAST_TWINING=$(grep -n 'twining_record\|twining_decide\|twining_post' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1 | cut -d: -f1) || LAST_TWINING=0
 LAST_TWINING=${LAST_TWINING:-0}
 
-# Allow if Twining recording happened after the last commit (or no prior commits)
-if [[ "$LAST_TWINING" -gt "$LAST_COMMIT" ]]; then
+# Allow if Twining recording happened at or after the last commit (or no prior commits).
+# Use >= rather than > to handle the case where twining_record and git commit are called
+# in the same assistant turn — Claude Code writes both tool calls to the transcript before
+# the PreToolUse hook fires, so their line numbers can be equal.
+if [[ "$LAST_TWINING" -ge "$LAST_COMMIT" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
* Change -gt to -ge when comparing LAST_TWINING vs LAST_COMMIT line numbers
* Claude Code writes all tool calls for a turn to the transcript before PreToolUse fires — equal line numbers are valid and should be allowed

Fixes Issue #11 
Only a change to a hook script so no testing/building.